### PR TITLE
Allows the platform to customize TLB operations

### DIFF
--- a/include/sbi/sbi_platform.h
+++ b/include/sbi/sbi_platform.h
@@ -56,6 +56,7 @@ struct sbi_domain_memregion;
 struct sbi_ecall_return;
 struct sbi_trap_regs;
 struct sbi_hart_features;
+struct sbi_tlb_info;
 union sbi_ldst_data;
 
 /** Possible feature flags of a platform */
@@ -124,6 +125,20 @@ struct sbi_platform_operations {
 
 	/** Get tlb fifo num entries*/
 	u32 (*get_tlb_num_entries)(void);
+
+	void (*local_fence_i)(struct sbi_tlb_info *tinfo);
+
+	void (*local_sfence_vma)(struct sbi_tlb_info *tinfo);
+
+	void (*local_sfence_vma_asid)(struct sbi_tlb_info *tinfo);
+
+	void (*local_hfence_gvma_vmid)(struct sbi_tlb_info *tinfo);
+
+	void (*local_hfence_gvma)(struct sbi_tlb_info *tinfo);
+
+	void (*local_hfence_vvma_asid)(struct sbi_tlb_info *tinfo);
+
+	void (*local_hfence_vvma)(struct sbi_tlb_info *tinfo);
 
 	/** Initialize platform timer during cold boot */
 	int (*timer_init)(void);
@@ -303,6 +318,81 @@ static inline u32 sbi_platform_tlb_fifo_num_entries(const struct sbi_platform *p
 	if (plat && sbi_platform_ops(plat)->get_tlb_num_entries)
 		return sbi_platform_ops(plat)->get_tlb_num_entries();
 	return sbi_hart_count();
+}
+
+static inline u32 sbi_platform_local_fence_i(
+					const struct sbi_platform *plat,
+					struct sbi_tlb_info *tinfo)
+{
+	if (plat && sbi_platform_ops(plat)->local_fence_i) {
+		sbi_platform_ops(plat)->local_fence_i(tinfo);
+		return 0;
+	}
+	return SBI_ENOTSUPP;
+}
+
+static inline u32 sbi_platform_local_sfence_vma(
+					const struct sbi_platform *plat,
+					struct sbi_tlb_info *tinfo)
+{
+	if (plat && sbi_platform_ops(plat)->local_sfence_vma) {
+		sbi_platform_ops(plat)->local_sfence_vma(tinfo);
+		return 0;
+	}
+	return SBI_ENOTSUPP;
+}
+
+static inline u32 sbi_platform_local_sfence_vma_asid(
+					const struct sbi_platform *plat,
+					struct sbi_tlb_info *tinfo)
+{
+	if (plat && sbi_platform_ops(plat)->local_sfence_vma_asid) {
+		sbi_platform_ops(plat)->local_sfence_vma_asid(tinfo);
+		return 0;
+	}
+	return SBI_ENOTSUPP;
+}
+
+static inline u32 sbi_platform_local_hfence_gvma_vmid(
+					const struct sbi_platform *plat,
+					struct sbi_tlb_info *tinfo)
+{
+	if (plat && sbi_platform_ops(plat)->local_hfence_gvma_vmid) {
+		sbi_platform_ops(plat)->local_hfence_gvma_vmid(tinfo);
+		return 0;
+	}
+	return SBI_ENOTSUPP;
+}
+
+static inline u32 sbi_platform_local_hfence_gvma(
+					const struct sbi_platform *plat,
+					struct sbi_tlb_info *tinfo)
+{
+	if (plat && sbi_platform_ops(plat)->local_hfence_gvma) {
+		sbi_platform_ops(plat)->local_hfence_gvma(tinfo);
+		return 0;
+	}
+	return SBI_ENOTSUPP;
+}
+static inline u32 sbi_platform_local_hfence_vvma_asid(
+					const struct sbi_platform *plat,
+					struct sbi_tlb_info *tinfo)
+{
+	if (plat && sbi_platform_ops(plat)->local_hfence_vvma_asid) {
+		sbi_platform_ops(plat)->local_hfence_vvma_asid(tinfo);
+		return 0;
+	}
+	return SBI_ENOTSUPP;
+}
+static inline u32 sbi_platform_local_hfence_vvma(
+					const struct sbi_platform *plat,
+					struct sbi_tlb_info *tinfo)
+{
+	if (plat && sbi_platform_ops(plat)->local_hfence_vvma) {
+		sbi_platform_ops(plat)->local_hfence_vvma(tinfo);
+		return 0;
+	}
+	return SBI_ENOTSUPP;
 }
 
 /**

--- a/lib/sbi/sbi_tlb.c
+++ b/lib/sbi/sbi_tlb.c
@@ -43,6 +43,10 @@ static void sbi_tlb_local_hfence_vvma(struct sbi_tlb_info *tinfo)
 
 	sbi_pmu_ctr_incr_fw(SBI_PMU_FW_HFENCE_VVMA_RCVD);
 
+	if (sbi_platform_local_hfence_vvma(
+			sbi_platform_thishart_ptr(), tinfo) == SBI_OK)
+		return;
+
 	hgatp = csr_swap(CSR_HGATP,
 			 (vmid << HGATP_VMID_SHIFT) & HGATP_VMID_MASK);
 
@@ -67,6 +71,10 @@ static void sbi_tlb_local_hfence_gvma(struct sbi_tlb_info *tinfo)
 
 	sbi_pmu_ctr_incr_fw(SBI_PMU_FW_HFENCE_GVMA_RCVD);
 
+	if (sbi_platform_local_hfence_gvma(
+			sbi_platform_thishart_ptr(), tinfo) == SBI_OK)
+		return;
+
 	if ((start == 0 && size == 0) || (size == SBI_TLB_FLUSH_ALL)) {
 		__sbi_hfence_gvma_all();
 		return;
@@ -84,6 +92,10 @@ static void sbi_tlb_local_sfence_vma(struct sbi_tlb_info *tinfo)
 	unsigned long i;
 
 	sbi_pmu_ctr_incr_fw(SBI_PMU_FW_SFENCE_VMA_RCVD);
+
+	if (sbi_platform_local_sfence_vma(
+			sbi_platform_thishart_ptr(), tinfo) == SBI_OK)
+		return;
 
 	if ((start == 0 && size == 0) || (size == SBI_TLB_FLUSH_ALL)) {
 		__sbi_sfence_vma_all();
@@ -107,6 +119,10 @@ static void sbi_tlb_local_hfence_vvma_asid(struct sbi_tlb_info *tinfo)
 	unsigned long i, hgatp;
 
 	sbi_pmu_ctr_incr_fw(SBI_PMU_FW_HFENCE_VVMA_ASID_RCVD);
+
+	if (sbi_platform_local_hfence_vvma_asid(
+			sbi_platform_thishart_ptr(), tinfo) == SBI_OK)
+		return;
 
 	hgatp = csr_swap(CSR_HGATP,
 			 (vmid << HGATP_VMID_SHIFT) & HGATP_VMID_MASK);
@@ -133,6 +149,10 @@ static void sbi_tlb_local_hfence_gvma_vmid(struct sbi_tlb_info *tinfo)
 
 	sbi_pmu_ctr_incr_fw(SBI_PMU_FW_HFENCE_GVMA_VMID_RCVD);
 
+	if (sbi_platform_local_hfence_gvma_vmid(
+			sbi_platform_thishart_ptr(), tinfo) == SBI_OK)
+		return;
+
 	if ((start == 0 && size == 0) || (size == SBI_TLB_FLUSH_ALL)) {
 		__sbi_hfence_gvma_vmid(vmid);
 		return;
@@ -151,6 +171,10 @@ static void sbi_tlb_local_sfence_vma_asid(struct sbi_tlb_info *tinfo)
 	unsigned long i;
 
 	sbi_pmu_ctr_incr_fw(SBI_PMU_FW_SFENCE_VMA_ASID_RCVD);
+
+	if (sbi_platform_local_sfence_vma_asid(
+			sbi_platform_thishart_ptr(), tinfo) == SBI_OK)
+		return;
 
 	/* Flush entire MM context for a given ASID */
 	if ((start == 0 && size == 0) || (size == SBI_TLB_FLUSH_ALL)) {
@@ -172,6 +196,10 @@ static void sbi_tlb_local_sfence_vma_asid(struct sbi_tlb_info *tinfo)
 static void sbi_tlb_local_fence_i(struct sbi_tlb_info *tinfo)
 {
 	sbi_pmu_ctr_incr_fw(SBI_PMU_FW_FENCE_I_RECVD);
+
+	if (sbi_platform_local_fence_i(
+			sbi_platform_thishart_ptr(), tinfo) == SBI_OK)
+		return;
 
 	__asm__ __volatile("fence.i");
 }

--- a/platform/generic/include/thead/c9xx_errata.h
+++ b/platform/generic/include/thead/c9xx_errata.h
@@ -8,6 +8,7 @@
  */
 #define THEAD_QUIRK_ERRATA_TLB_FLUSH		BIT(0)
 #define THEAD_QUIRK_ERRATA_THEAD_PMU		BIT(1)
+#define THEAD_QUIRK_ERRATA_JTLB			BIT(2)
 
 void thead_register_tlb_flush_trap_handler(void);
 

--- a/platform/generic/thead/thead-generic.c
+++ b/platform/generic/thead/thead-generic.c
@@ -13,6 +13,7 @@
 #include <sbi/sbi_platform.h>
 #include <sbi/sbi_scratch.h>
 #include <sbi/sbi_string.h>
+#include <sbi/sbi_tlb.h>
 #include <sbi_utils/fdt/fdt_helper.h>
 
 struct thead_generic_quirks {
@@ -39,6 +40,32 @@ static int thead_pmu_extensions_init(struct sbi_hart_features *hfeatures)
 	return 0;
 }
 
+static void thead_jtlb_local_sfence_vma(struct sbi_tlb_info *tinfo)
+{
+	__asm__ __volatile__("sfence.vma");
+}
+
+static void thead_jtlb_local_hfence_vvma_asid(struct sbi_tlb_info *tinfo)
+{
+	unsigned long start = tinfo->start;
+	unsigned long size  = tinfo->size;
+	unsigned long asid  = tinfo->asid;
+
+	/* Flush entire MM context for a given ASID */
+	if ((start == 0 && size == 0) || (size == SBI_TLB_FLUSH_ALL)) {
+		__asm__ __volatile__("sfence.vma x0, %0"
+				     :
+				     : "r"(asid)
+				     : "memory");
+		return;
+	}
+
+	__asm__ __volatile__("sfence.vma x0, %0"
+			     :
+			     : "r"(asid)
+			     : "memory");
+}
+
 static int thead_generic_platform_init(const void *fdt, int nodeoff,
 				       const struct fdt_match *match)
 {
@@ -48,6 +75,11 @@ static int thead_generic_platform_init(const void *fdt, int nodeoff,
 		generic_platform_ops.early_init = thead_tlb_flush_early_init;
 	if (quirks->errata & THEAD_QUIRK_ERRATA_THEAD_PMU)
 		generic_platform_ops.extensions_init = thead_pmu_extensions_init;
+
+	if (quirks->errata &THEAD_QUIRK_ERRATA_JTLB) {
+		generic_platform_ops.local_sfence_vma = thead_jtlb_local_sfence_vma;
+		generic_platform_ops.local_sfence_vma_asid = thead_jtlb_local_hfence_vvma_asid;
+	}
 
 	return 0;
 }
@@ -60,13 +92,17 @@ static const struct thead_generic_quirks thead_pmu_quirks = {
 	.errata = THEAD_QUIRK_ERRATA_THEAD_PMU,
 };
 
+static const struct thead_generic_quirks thead_pmu_jtlb_quirks = {
+	.errata = THEAD_QUIRK_ERRATA_THEAD_PMU | THEAD_QUIRK_ERRATA_JTLB,
+};
+
 static const struct fdt_match thead_generic_match[] = {
 	{ .compatible = "canaan,kendryte-k230", .data = &thead_pmu_quirks },
 	{ .compatible = "sophgo,cv1800b", .data = &thead_pmu_quirks },
 	{ .compatible = "sophgo,cv1812h", .data = &thead_pmu_quirks },
 	{ .compatible = "sophgo,sg2000", .data = &thead_pmu_quirks },
 	{ .compatible = "sophgo,sg2002", .data = &thead_pmu_quirks },
-	{ .compatible = "sophgo,sg2044", .data = &thead_pmu_quirks },
+	{ .compatible = "sophgo,sg2044", .data = &thead_pmu_jtlb_quirks },
 	{ .compatible = "thead,th1520", .data = &thead_th1520_quirks },
 	{ },
 };


### PR DESCRIPTION
## Summary by Sourcery

Introduce platform-specific hooks for local TLB and cache fence operations and wire them into the TLB handling path, with Thead generic platforms optionally overriding default behavior via errata quirks.

New Features:
- Add optional platform operations to override local fence.i, sfence.vma, sfence.vma.asid, and hypervisor fence variants using TLB flush metadata.
- Allow Thead generic platforms with JTLB errata to provide custom sfence.vma and sfence.vma.asid implementations selected via device-tree quirks.

Enhancements:
- Update core TLB handling to invoke platform-specific local fence callbacks when available, falling back to the existing generic instructions otherwise.
- Extend Thead errata flags to cover JTLB behavior and adjust compatible matching to enable the new TLB handling on affected SoCs.